### PR TITLE
Gitignore a few more autogenerated LaTex files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.aux
+*.bbl
+*.blg
+*.dvi
 *.log
 *.out
 *.synctex.gz


### PR DESCRIPTION
I don't know what LaTex does with them, but these files always show up for me and we don't track them anyway.